### PR TITLE
Add open_in_browser configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ LetterOpener.configure do |config|
   # scheme doesn't work for you.
   # Default value is blank
   config.file_uri_scheme = 'file://///wsl$/Ubuntu-18.04'
+
+  # To control whether emails are automatically opened in the browser.
+  # Default value is `true`
+  config.open_in_browser = true
+
+  # You can also disable automatic opening completely
+  config.open_in_browser = false
+
+  # Or use a callable to conditionally open emails based on email properties
+  config.open_in_browser = ->(mail) { mail.to.include?('important@example.com') }
+  
+  # Example: Only open emails with "urgent" in the subject
+  config.open_in_browser = ->(mail) { mail.subject&.include?('urgent') }
 end
 ```
 
@@ -47,7 +60,9 @@ If you aren't using Rails, this can be easily set up with the Mail gem. Just set
 ```rb
 require "letter_opener"
 Mail.defaults do
-  delivery_method LetterOpener::DeliveryMethod, location: File.expand_path('../tmp/letter_opener', __FILE__)
+  delivery_method LetterOpener::DeliveryMethod, 
+    location: File.expand_path('../tmp/letter_opener', __FILE__),
+    open_in_browser: false  # Optional: disable automatic browser opening
 end
 ```
 
@@ -57,7 +72,10 @@ The method is similar if you're using the Pony gem:
 require "letter_opener"
 Pony.options = {
   via: LetterOpener::DeliveryMethod,
-  via_options: {location: File.expand_path('../tmp/letter_opener', __FILE__)}
+  via_options: {
+    location: File.expand_path('../tmp/letter_opener', __FILE__),
+    open_in_browser: false  # Optional: disable automatic browser opening
+  }
 }
 ```
 
@@ -65,7 +83,9 @@ Alternatively, if you are using ActionMailer directly (without Rails) you will n
 
 ```rb
 require "letter_opener"
-ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, :location => File.expand_path('../tmp/letter_opener', __FILE__)
+ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, 
+  location: File.expand_path('../tmp/letter_opener', __FILE__),
+  open_in_browser: false  # Optional: disable automatic browser opening
 ActionMailer::Base.delivery_method = :letter_opener
 ```
 

--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -1,11 +1,12 @@
 module LetterOpener
   class Configuration
-    attr_accessor :location, :message_template, :file_uri_scheme
+    attr_accessor :location, :message_template, :file_uri_scheme, :open_in_browser
 
     def initialize
       @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
       @message_template = 'default'
       @file_uri_scheme = nil
+      @open_in_browser = true
     end
   end
 end

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -11,6 +11,7 @@ module LetterOpener
       options[:message_template] ||= LetterOpener.configuration.message_template
       options[:location] ||= LetterOpener.configuration.location
       options[:file_uri_scheme] ||= LetterOpener.configuration.file_uri_scheme
+      options[:open_in_browser] = options.fetch(:open_in_browser, LetterOpener.configuration.open_in_browser)
 
       raise InvalidOption, "A location option is required when using the Letter Opener delivery method" if options[:location].nil?
 
@@ -22,7 +23,16 @@ module LetterOpener
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
 
       messages = Message.rendered_messages(mail, location: location, message_template: settings[:message_template])
-      ::Launchy.open("#{settings[:file_uri_scheme]}#{messages.first.filepath}")
+      
+      open_in_browser = settings[:open_in_browser]
+      should_open = case open_in_browser
+                    when Proc
+                      open_in_browser.call(mail)
+                    else
+                      open_in_browser
+                    end
+      
+      ::Launchy.open("#{settings[:file_uri_scheme]}#{messages.first.filepath}") if should_open
     end
 
     private

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -413,4 +413,156 @@ describe LetterOpener::DeliveryMethod do
       end
     end
   end
+
+  context 'open_in_browser configuration' do
+    after do
+      LetterOpener.configure do |config|
+        config.open_in_browser = true
+      end
+    end
+
+    context 'when open_in_browser is true (default)' do
+      it 'opens the email in browser' do
+        expect(Launchy).to receive(:open)
+
+        Mail.deliver do
+          from 'foo@example.com'
+          to   'bar@example.com'
+          body 'Test message'
+        end
+      end
+    end
+
+    context 'when open_in_browser is false' do
+      before do
+        Mail.defaults do
+          delivery_method LetterOpener::DeliveryMethod, 
+            location: File.expand_path('../../../tmp/letter_opener', __FILE__),
+            open_in_browser: false
+        end
+      end
+
+      it 'does not open the email in browser' do
+        expect(Launchy).not_to receive(:open)
+
+        Mail.deliver do
+          from 'foo@example.com'
+          to   'bar@example.com'
+          body 'Test message'
+        end
+      end
+
+      it 'still creates the email files' do
+        expect(Launchy).not_to receive(:open)
+
+        Mail.deliver do
+          from 'foo@example.com'
+          to   'bar@example.com'
+          body 'Test message'
+        end
+
+        expect(File.exist?(plain_file)).to be_truthy
+      end
+    end
+
+    context 'when open_in_browser is a proc' do
+      context 'returning true' do
+        before do
+          Mail.defaults do
+            delivery_method LetterOpener::DeliveryMethod, 
+              location: File.expand_path('../../../tmp/letter_opener', __FILE__),
+              open_in_browser: ->(mail) { mail.to.include?('important@example.com') }
+          end
+        end
+
+        it 'opens emails matching the condition' do
+          expect(Launchy).to receive(:open)
+
+          Mail.deliver do
+            from 'foo@example.com'
+            to   'important@example.com'
+            body 'Important message'
+          end
+        end
+
+        it 'does not open emails not matching the condition' do
+          expect(Launchy).not_to receive(:open)
+
+          Mail.deliver do
+            from 'foo@example.com'
+            to   'regular@example.com'
+            body 'Regular message'
+          end
+        end
+      end
+
+      context 'with access to mail properties' do
+        before do
+          Mail.defaults do
+            delivery_method LetterOpener::DeliveryMethod, 
+              location: File.expand_path('../../../tmp/letter_opener', __FILE__),
+              open_in_browser: ->(mail) { 
+                mail.subject && mail.subject.include?('urgent')
+              }
+          end
+        end
+
+        it 'opens emails with urgent subject' do
+          expect(Launchy).to receive(:open)
+
+          Mail.deliver do
+            from    'foo@example.com'
+            to      'bar@example.com'
+            subject 'urgent: Please review'
+            body    'Important message'
+          end
+        end
+
+        it 'does not open emails without urgent subject' do
+          expect(Launchy).not_to receive(:open)
+
+          Mail.deliver do
+            from    'foo@example.com'
+            to      'bar@example.com'
+            subject 'Regular update'
+            body    'Regular message'
+          end
+        end
+      end
+    end
+
+    context 'when open_in_browser is set via delivery_method options' do
+      it 'overrides the global configuration when false' do
+        expect(Launchy).not_to receive(:open)
+
+        Mail.defaults do
+          delivery_method LetterOpener::DeliveryMethod, 
+            location: File.expand_path('../../../tmp/letter_opener', __FILE__),
+            open_in_browser: false
+        end
+
+        Mail.deliver do
+          from 'foo@example.com'
+          to   'bar@example.com'
+          body 'Test message'
+        end
+      end
+
+      it 'overrides the global configuration when proc' do
+        expect(Launchy).to receive(:open)
+
+        Mail.defaults do
+          delivery_method LetterOpener::DeliveryMethod, 
+            location: File.expand_path('../../../tmp/letter_opener', __FILE__),
+            open_in_browser: ->(mail) { mail.to.include?('special@example.com') }
+        end
+
+        Mail.deliver do
+          from 'foo@example.com'
+          to   'special@example.com'
+          body 'Test message'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `open_in_browser` configuration option to control automatic email opening in browser
- Support both boolean values and callable/proc for conditional email opening based on email properties

## Test plan
- [x] All existing tests continue to pass
- [x] New tests cover boolean true/false scenarios
- [x] New tests cover callable/proc scenarios with email property evaluation
- [x] Tests verify email files are still created when browser opening is disabled
- [x] Tests confirm delivery method options override global configuration

🤖 Generated with [Claude Code](https://claude.ai/code)